### PR TITLE
Build libyaml locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@
 erl_crash.dump
 *.ez
 
-/priv/*.so
+/priv/*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,43 @@
+MIX = mix
+CFLAGS = -g -O3 -ansi -pedantic -Wall -Wextra -Wno-unused-parameter
+
+ERLANG_PATH = $(shell erl -eval 'io:format("~s", [lists:concat([code:root_dir(), "/erts-", erlang:system_info(version), "/include"])])' -s init stop -noshell)
+CFLAGS += -I$(ERLANG_PATH)
+
+ifeq ($(wildcard deps/yaml),)
+	YAML_PATH = ../yaml
+else
+	YAML_PATH = deps/yaml
+endif
+
+CFLAGS += -I$(YAML_PATH)/include
+
+ifneq ($(OS),Windows_NT)
+	CFLAGS += -fPIC
+
+	ifeq ($(shell uname),Darwin)
+		LDFLAGS += -dynamiclib -undefined dynamic_lookup
+	endif
+endif
+
+.PHONY: all yomel clean
+
+all: yomel
+
+yomel:
+	$(MIX) compile
+
+$(YAML_PATH)/src/.libs/libyaml.a:
+	cd $(YAML_PATH) && ./bootstrap && ./configure
+	$(MAKE) -C $(YAML_PATH)/src
+
+priv/yomel.so: priv $(YAML_PATH)/src/.libs/libyaml.a c_src/yomel_nif.c
+	$(CC) $(CFLAGS) -shared $(LDFLAGS) -o $@ c_src/*.c $(YAML_PATH)/src/.libs/libyaml.a
+
+priv:
+	mkdir priv
+
+clean:
+	$(MIX) clean
+	$(MAKE) -C $(YAML_PATH) clean
+	rm -r priv/*

--- a/mix.exs
+++ b/mix.exs
@@ -1,30 +1,14 @@
-defmodule Mix.Tasks.Compile.Nif do
-  use Mix.Task
-
-  @shortdoc "compile C source"
-
-  @compiler "clang"
-  @erl_flag "-I#{:code.root_dir}/erts-#{:erlang.system_info :version}/include"
-  @c_files  [__DIR__, "c_src", "*.c"] |> Path.join |> Path.wildcard
-  @out_opt  "-o #{Path.join [__DIR__, "priv", "yomel.so"]}"
+defmodule Mix.Tasks.Compile.Yaml do
+  @shortdoc "Compiles libyaml"
 
   def run(_) do
-    [__DIR__, "priv"]
-    |> Path.join
-    |> File.mkdir_p!
-
-    [@compiler, @erl_flag, @c_files, shared_opts, @out_opt]
-    |> List.flatten
-    |> Enum.join(" ")
-    |> Mix.shell.cmd
-  end
-
-  defp shared_opts, do: ["-shared" | os_shared_opts]
-
-  defp os_shared_opts do
-    case :os.type do
-      {:unix, :darwin} -> ~w(-dynamiclib -undefined dynamic_lookup -lyaml)
-      _other -> []
+    # TODO: Totally untested
+    if match? {:win32, _}, :os.type do
+      raise RuntimeError, message: "Compiling on windows is not currently supported"
+    else
+      {result, _error_code} = System.cmd("make", ["priv/yomel.so"], stderr_to_stdout: true)
+      IO.binwrite result
+      :ok
     end
   end
 end
@@ -35,12 +19,12 @@ defmodule Yomel.Mixfile do
   def project do
     [app: :yomel,
      version: "0.2.2",
-     elixir: "~> 1.0",
+     elixir: "~> 1.2.0",
      description: description,
      package: package,
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     compilers: [:nif | Mix.compilers],
+     compilers: [:yaml, :elixir, :app],
      deps: deps,
      docs: docs]
   end
@@ -51,7 +35,8 @@ defmodule Yomel.Mixfile do
 
   defp deps do
     [{:earmark, "~> 0.1", only: :dev},
-     {:ex_doc,  "~> 0.7", only: :dev}]
+     {:ex_doc,  "~> 0.7", only: :dev},
+     {:yaml, git: "git@github.com:yaml/libyaml.git", tag: "0.1.4", app: false, compile: "./bootstrap && ./configure"}]
   end
 
   defp description do

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,3 @@
 %{"earmark": {:hex, :earmark, "0.1.16"},
-  "ex_doc": {:hex, :ex_doc, "0.7.2"}}
+  "ex_doc": {:hex, :ex_doc, "0.7.2"},
+  "yaml": {:git, "git@github.com:yaml/libyaml.git", "2bf46f346d875c8c887411844e78922b5190bc33", [tag: "0.1.4"]}}


### PR DESCRIPTION
For your consideration.

This adds libyaml as a dependency (tagged to latest release on github), compiles it and builds yomel.so against that.

Rationale:
- Avoids errors like #9 where the local libyaml install cannot be found (e.g., if installed to a non-standard path).
- Ensures yomel is running against the latest release of libyaml.

I am not great with Makefiles and such, so I copied the patterns in the [elixir markdown library](https://github.com/devinus/markdown) (which builds against a local version of hoedown). 
