### PR TITLE
Honor CFLAGS and LDFLAGS in build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@
 erl_crash.dump
 *.ez
 
-/priv/*.so
+/priv/*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+MIX = mix
+CFLAGS += -g -O3 -ansi -pedantic -Wall -Wextra -Wno-unused-parameter
+
+ERLANG_PATH = $(shell erl -eval 'io:format("~s", [lists:concat([code:root_dir(), "/erts-", erlang:system_info(version), "/include"])])' -s init stop -noshell)
+CFLAGS += -I$(ERLANG_PATH)
+
+ifneq ($(OS),Windows_NT)
+	CFLAGS += -fPIC
+
+	ifeq ($(shell uname),Darwin)
+		LDFLAGS += -dynamiclib -undefined dynamic_lookup -lyaml
+	endif
+endif
+
+.PHONY: all yomel clean
+
+all: yomel
+
+yomel:
+	$(MIX) compile
+
+priv/yomel.so: priv c_src/yomel_nif.c
+	$(CC) $(CFLAGS) -shared $(LDFLAGS) -o $@ c_src/*.c
+
+priv:
+	mkdir priv
+
+clean:
+	$(MIX) clean
+	rm -r priv/*

--- a/mix.exs
+++ b/mix.exs
@@ -3,29 +3,15 @@ defmodule Mix.Tasks.Compile.Nif do
 
   @shortdoc "compile C source"
 
-  @compiler "clang"
-  @erl_flag "-I#{:code.root_dir}/erts-#{:erlang.system_info :version}/include"
-  @c_files  [__DIR__, "c_src", "*.c"] |> Path.join |> Path.wildcard
-  @out_opt  "-o #{Path.join [__DIR__, "priv", "yomel.so"]}"
-
   def run(_) do
-    [__DIR__, "priv"]
-    |> Path.join
-    |> File.mkdir_p!
-
-    [@compiler, @erl_flag, @c_files, shared_opts, @out_opt]
-    |> List.flatten
-    |> Enum.join(" ")
-    |> Mix.shell.cmd
-  end
-
-  defp shared_opts, do: ["-shared" | os_shared_opts]
-
-  defp os_shared_opts do
-    case :os.type do
-      {:unix, :darwin} -> ~w(-dynamiclib -undefined dynamic_lookup -lyaml)
-      _other -> []
+    if match? {:win32, _}, :os.type do
+      raise RuntimeError, message: "Windows is not currently supported"
+    else
+      {result, _error_code} = System.cmd("make", ["priv/yomel.so"], stderr_to_stdout: true)
+      IO.binwrite result
     end
+    
+    :ok
   end
 end
 


### PR DESCRIPTION
An alternative to #13, this moves the build to a Makefile and allows building against non-standard libyaml installations, e.g.

``` sh
CFLAGS="-L/opt/homebrew/lib -I/opt/homebrew/include" mix compile
```
